### PR TITLE
Using NPM proxy (requires sinopia)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,6 +52,12 @@ else
 fi
 install_npm
 
+# use npm proxy
+npm set registry http://sinopia.marathon.mesos:4873
+
+# ("null" means get CA list from OS)
+$ npm set ca null
+
 ####### Build the project's dependencies
 
 head "Building dependencies"


### PR DESCRIPTION
See https://github.com/elasticio/marathon/commit/4fed54a53eb32f298404ba1ec6142f0b00703f39

Improves time for `npm install` by ~60%
